### PR TITLE
Distinguish linear and sRGB color constructors

### DIFF
--- a/crates/plinth/src/graphics/color.rs
+++ b/crates/plinth/src/graphics/color.rs
@@ -1,7 +1,7 @@
 use bytemuck::Pod;
 use bytemuck::Zeroable;
 
-// All colors are in linear sRGB space.
+// All colors are stored in linear sRGB space.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
 pub struct Color {
@@ -12,63 +12,24 @@ pub struct Color {
 }
 
 impl Color {
-    pub const TRANSPARENT: Self = Self {
-        r: 0.0,
-        g: 0.0,
-        b: 0.0,
-        a: 0.0,
-    };
+    pub const TRANSPARENT: Self = Self::linear(0.0, 0.0, 0.0, 0.0);
+    pub const BLACK: Self = Self::linear(0.0, 0.0, 0.0, 1.0);
+    pub const LIGHT_GRAY: Self = Self::linear(0.8, 0.8, 0.8, 1.0);
+    pub const DARK_GRAY: Self = Self::linear(0.2, 0.2, 0.2, 1.0);
+    pub const WHITE: Self = Self::linear(1.0, 1.0, 1.0, 1.0);
+    pub const RED: Self = Self::linear(1.0, 0.0, 0.0, 1.0);
+    pub const BLUE: Self = Self::linear(0.0, 0.0, 1.0, 1.0);
+    pub const GREEN: Self = Self::linear(0.0, 1.0, 0.0, 1.0);
 
-    pub const BLACK: Self = Self {
-        r: 0.0,
-        g: 0.0,
-        b: 0.0,
-        a: 1.0,
-    };
+    /// Construct a color directly from linear sRGB components without any
+    /// gamma conversion. Use this when the inputs are already linear.
+    pub const fn linear(r: f32, g: f32, b: f32, a: f32) -> Self {
+        Self { r, g, b, a }
+    }
 
-    pub const LIGHT_GRAY: Self = Self {
-        r: 0.8,
-        g: 0.8,
-        b: 0.8,
-        a: 1.0,
-    };
-
-    pub const DARK_GRAY: Self = Self {
-        r: 0.2,
-        g: 0.2,
-        b: 0.2,
-        a: 1.0,
-    };
-
-    pub const WHITE: Self = Self {
-        r: 1.0,
-        g: 1.0,
-        b: 1.0,
-        a: 1.0,
-    };
-
-    pub const RED: Self = Self {
-        r: 1.0,
-        g: 0.0,
-        b: 0.0,
-        a: 1.0,
-    };
-
-    pub const BLUE: Self = Self {
-        r: 0.0,
-        g: 0.0,
-        b: 1.0,
-        a: 1.0,
-    };
-
-    pub const GREEN: Self = Self {
-        r: 0.0,
-        g: 1.0,
-        b: 0.0,
-        a: 1.0,
-    };
-
-    pub fn srgb(r: f32, g: f32, b: f32, a: f32) -> Self {
+    /// Construct a color from non-linear (gamma-encoded) sRGB components,
+    /// converting them into the linear sRGB representation used internally.
+    pub fn srgb_nonlinear(r: f32, g: f32, b: f32, a: f32) -> Self {
         let srgb =
             color::AlphaColor::<color::Srgb>::new([r, g, b, a]).convert::<color::LinearSrgb>();
 
@@ -78,6 +39,18 @@ impl Color {
             b: srgb.components[2],
             a: srgb.components[3],
         }
+    }
+
+    /// Return a copy of this color with the alpha channel replaced.
+    pub const fn with_alpha(mut self, a: f32) -> Self {
+        self.a = a;
+        self
+    }
+
+    /// Return a copy of this color with the alpha channel multiplied by `factor`.
+    pub const fn mul_alpha(mut self, factor: f32) -> Self {
+        self.a *= factor;
+        self
     }
 }
 

--- a/crates/plinth/src/ui/style.rs
+++ b/crates/plinth/src/ui/style.rs
@@ -34,16 +34,16 @@ mod tests {
                 vec![
                     (
                         StateFlags::NORMAL,
-                        StyleProperty::Background(Paint::solid(Color::srgb(0.2, 0.2, 0.2, 1.0))),
+                        StyleProperty::Background(Paint::solid(Color::srgb_nonlinear(0.2, 0.2, 0.2, 1.0))),
                     ),
                     (StateFlags::NORMAL, StyleProperty::TextColor(Color::WHITE)),
                     (
                         StateFlags::HOVERED,
-                        StyleProperty::Background(Paint::solid(Color::srgb(0.3, 0.3, 0.3, 1.0))),
+                        StyleProperty::Background(Paint::solid(Color::srgb_nonlinear(0.3, 0.3, 0.3, 1.0))),
                     ),
                     (
                         StateFlags::PRESSED,
-                        StyleProperty::Background(Paint::solid(Color::srgb(0.1, 0.1, 0.1, 1.0))),
+                        StyleProperty::Background(Paint::solid(Color::srgb_nonlinear(0.1, 0.1, 0.1, 1.0))),
                     ),
                 ],
             )
@@ -56,11 +56,11 @@ mod tests {
                 vec![
                     (
                         StateFlags::NORMAL,
-                        StyleProperty::Background(Paint::solid(Color::srgb(0.0, 0.4, 0.8, 1.0))),
+                        StyleProperty::Background(Paint::solid(Color::srgb_nonlinear(0.0, 0.4, 0.8, 1.0))),
                     ),
                     (
                         StateFlags::HOVERED,
-                        StyleProperty::Background(Paint::solid(Color::srgb(0.0, 0.5, 1.0, 1.0))),
+                        StyleProperty::Background(Paint::solid(Color::srgb_nonlinear(0.0, 0.5, 1.0, 1.0))),
                     ),
                 ],
             )
@@ -74,13 +74,13 @@ mod tests {
         let primary_text: Color = registry.resolve::<TextColor>(button_primary, StateFlags::NORMAL);
 
         // Base button colors
-        assert_eq!(base_normal, Paint::solid(Color::srgb(0.2, 0.2, 0.2, 1.0)));
-        assert_eq!(base_hovered, Paint::solid(Color::srgb(0.3, 0.3, 0.3, 1.0)));
+        assert_eq!(base_normal, Paint::solid(Color::srgb_nonlinear(0.2, 0.2, 0.2, 1.0)));
+        assert_eq!(base_hovered, Paint::solid(Color::srgb_nonlinear(0.3, 0.3, 0.3, 1.0)));
 
         // Primary inherits text color, overrides background
         assert_eq!(
             primary_normal,
-            Paint::solid(Color::srgb(0.0, 0.4, 0.8, 1.0))
+            Paint::solid(Color::srgb_nonlinear(0.0, 0.4, 0.8, 1.0))
         );
         assert_eq!(primary_text, Color::WHITE); // Inherited from base
     }

--- a/crates/plinth/src/ui/style/properties.rs
+++ b/crates/plinth/src/ui/style/properties.rs
@@ -103,7 +103,7 @@ macros::declare_style! {
         underline_offset: UnderlineOffset(f32) = 0.0,
 
         // text editing styles
-        selection_color: SelectionColor(Color) = Color::srgb(0.2, 0.4, 0.8, 0.3),
+        selection_color: SelectionColor(Color) = Color::srgb_nonlinear(0.2, 0.4, 0.8, 0.3),
         selection_text_color: SelectionTextColor(Color) = Color::WHITE,
         cursor_color: CursorColor(Color) = Color::BLACK,
     }

--- a/crates/plinth/src/ui/style/registry.rs
+++ b/crates/plinth/src/ui/style/registry.rs
@@ -197,7 +197,7 @@ mod tests {
 
     // Helper to create colors from 0-255 RGB values
     fn rgb(r: u8, g: u8, b: u8) -> Color {
-        Color::srgb(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0)
+        Color::srgb_nonlinear(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0)
     }
 
     // ==================== Registration Tests ====================

--- a/crates/plinth/src/ui/theme.rs
+++ b/crates/plinth/src/ui/theme.rs
@@ -392,11 +392,11 @@ fn default_theme() -> Theme {
                 ),
                 (
                     StateFlags::HOVERED,
-                    StyleProperty::Background(Paint::solid(Color::srgb(0.92, 0.92, 0.92, 1.0))),
+                    StyleProperty::Background(Paint::solid(Color::srgb_nonlinear(0.92, 0.92, 0.92, 1.0))),
                 ),
                 (
                     StateFlags::PRESSED,
-                    StyleProperty::Background(Paint::solid(Color::srgb(0.86, 0.86, 0.86, 1.0))),
+                    StyleProperty::Background(Paint::solid(Color::srgb_nonlinear(0.86, 0.86, 0.86, 1.0))),
                 ),
                 (
                     StateFlags::empty(),

--- a/examples/layout_center.rs
+++ b/examples/layout_center.rs
@@ -54,7 +54,7 @@ impl AppWindow {
     }
 
     fn update(&mut self, _context: Context, mut ui: UiBuilder) {
-        ui.color(Color::srgb(0.1, 0.2, 0.3, 1.0))
+        ui.color(Color::srgb_nonlinear(0.1, 0.2, 0.3, 1.0))
             .child_alignment(Alignment::Center, Alignment::Center)
             .with_child(|ui| {
                 ui.child_direction(LayoutDirection::Vertical)

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
     theme.set_base_style([
         (
             StateFlags::NORMAL,
-            StyleProperty::Background(Paint::solid(Color::srgb(0.1, 0.2, 0.3, 1.0))),
+            StyleProperty::Background(Paint::solid(Color::srgb_nonlinear(0.1, 0.2, 0.3, 1.0))),
         ),
         (StateFlags::NORMAL, StyleProperty::FontSize(32)),
     ]);
@@ -152,7 +152,7 @@ impl ViewportState {
     }
 
     fn update(&mut self, _context: Context, mut ui: UiBuilder) {
-        ui.color(Color::srgb(0.1, 0.2, 0.3, 1.0))
+        ui.color(Color::srgb_nonlinear(0.1, 0.2, 0.3, 1.0))
             .child_alignment(Alignment::Center, Alignment::Center);
 
         let mut menu = ui.child();


### PR DESCRIPTION
## Summary
- Rename `Color::srgb(...)` to `Color::srgb_nonlinear(...)` so the gamma conversion is no longer hidden behind a misleading name.
- Add `Color::linear(...)` (`const fn`) for inputs that are already linear, and rewrite the const colors (`BLACK`, `WHITE`, etc.) to use it.
- Add `Color::with_alpha(a)` and `Color::mul_alpha(factor)` helpers.
- Update all call sites in `theme.rs`, `style.rs`, `style/properties.rs`, `style/registry.rs`, `examples/layout_center.rs`, and `src/main.rs`.

Implements finding #20. Pre-1.0 API change.

## Test plan
- [x] `cargo check --examples --bin sabre --tests`
- [ ] Manual: visual output of `cargo run --bin sabre`, `cargo run --example counter`, `cargo run --example temp_converter` matches main