### PR TITLE
Replace AppLifecycleHandler trait with closure setters

### DIFF
--- a/crates/plinth/src/shell.rs
+++ b/crates/plinth/src/shell.rs
@@ -8,7 +8,6 @@ mod winit;
 
 pub use app_context::AppContext;
 pub use app_context::AppContextBuilder;
-pub use app_context::AppLifecycleHandler;
 pub use clipboard::Clipboard;
 pub use frame::Context;
 pub use frame::FileDialog;

--- a/crates/plinth/src/shell/app_context.rs
+++ b/crates/plinth/src/shell/app_context.rs
@@ -27,6 +27,8 @@ use super::winit::WinitWindow;
 #[derive(Default)]
 pub struct AppContextBuilder {
     theme: Option<Theme>,
+    on_resume: Option<Box<dyn FnMut(&mut AppContext)>>,
+    on_suspend: Option<Box<dyn FnMut(&mut AppContext)>>,
 }
 
 impl AppContextBuilder {
@@ -35,7 +37,23 @@ impl AppContextBuilder {
         self
     }
 
-    pub fn run(self, handler: impl AppLifecycleHandler) {
+    pub fn on_resume<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&mut AppContext) + 'static,
+    {
+        self.on_resume = Some(Box::new(f));
+        self
+    }
+
+    pub fn on_suspend<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&mut AppContext) + 'static,
+    {
+        self.on_suspend = Some(Box::new(f));
+        self
+    }
+
+    pub fn run(self) {
         let event_loop = EventLoop::builder().with_dpi_aware(true).build().unwrap();
         event_loop.set_control_flow(ControlFlow::Wait);
 
@@ -53,19 +71,12 @@ impl AppContextBuilder {
                 format_buffer: String::with_capacity(2048),
             },
             windows: HashMap::new(),
-            user_handler: handler,
+            on_resume: self.on_resume,
+            on_suspend: self.on_suspend,
         };
 
         event_loop.run_app(runtime).unwrap();
     }
-}
-
-pub trait AppLifecycleHandler: 'static {
-    fn suspend(&mut self, runtime: &mut AppContext) {
-        let _ = runtime;
-    }
-
-    fn resume(&mut self, runtime: &mut AppContext);
 }
 
 pub struct AppContext {

--- a/crates/plinth/src/shell/winit.rs
+++ b/crates/plinth/src/shell/winit.rs
@@ -18,7 +18,6 @@ use crate::ui::UiBuilder;
 use crate::ui::context::UiContext;
 
 use super::app_context::AppContext;
-use super::app_context::AppLifecycleHandler;
 use super::frame::Context;
 use super::window::ViewportId;
 
@@ -39,14 +38,15 @@ pub(super) enum DeferredCommand {
     },
 }
 
-pub(super) struct WinitApp<App> {
+pub(super) struct WinitApp {
     pub runtime: AppContext,
     pub windows: HashMap<WindowId, WinitWindow>,
 
-    pub user_handler: App,
+    pub on_resume: Option<Box<dyn FnMut(&mut AppContext)>>,
+    pub on_suspend: Option<Box<dyn FnMut(&mut AppContext)>>,
 }
 
-impl<App> WinitApp<App> {
+impl WinitApp {
     fn handle_deferred_commands(&mut self, event_loop: &dyn ActiveEventLoop) {
         for command in self.runtime.deferred_commands.drain(..) {
             match command {
@@ -92,14 +92,23 @@ impl<App> WinitApp<App> {
     }
 }
 
-impl<App: AppLifecycleHandler> ApplicationHandler for WinitApp<App> {
+impl ApplicationHandler for WinitApp {
     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-        self.user_handler.resume(&mut self.runtime);
+        if let Some(on_resume) = self.on_resume.as_mut() {
+            on_resume(&mut self.runtime);
+        }
         self.handle_deferred_commands(event_loop);
 
         self.runtime.repaint(self.windows.values_mut().inspect(|w| {
             w.window.set_visible(true);
         }));
+    }
+
+    fn destroy_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
+        let _ = event_loop;
+        if let Some(on_suspend) = self.on_suspend.as_mut() {
+            on_suspend(&mut self.runtime);
+        }
     }
 
     fn window_event(

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -5,9 +5,7 @@
 #![allow(unused_crate_dependencies)]
 
 use plinth::graphics::Color;
-use plinth::shell::AppContext;
 use plinth::shell::AppContextBuilder;
-use plinth::shell::AppLifecycleHandler;
 use plinth::shell::Context;
 use plinth::shell::WindowConfig;
 use plinth::ui::Alignment;
@@ -17,22 +15,18 @@ use plinth::ui::UiBuilder;
 
 fn main() {
     tracing_subscriber::fmt().pretty().init();
-    AppContextBuilder::default().run(Demo {});
-}
-
-struct Demo {}
-
-impl AppLifecycleHandler for Demo {
-    fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
-            WindowConfig {
-                title: "Counter".into(),
-                width: 400,
-                height: 300,
-            },
-            AppWindow::default().into_handler(),
-        );
-    }
+    AppContextBuilder::default()
+        .on_resume(|runtime| {
+            runtime.create_viewport(
+                WindowConfig {
+                    title: "Counter".into(),
+                    width: 400,
+                    height: 300,
+                },
+                AppWindow::default().into_handler(),
+            );
+        })
+        .run();
 }
 
 #[derive(Default)]

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -3,9 +3,7 @@
 
 #![allow(unused_crate_dependencies)]
 
-use plinth::shell::AppContext;
 use plinth::shell::AppContextBuilder;
-use plinth::shell::AppLifecycleHandler;
 use plinth::shell::Context;
 use plinth::shell::WindowConfig;
 use plinth::ui::Alignment;
@@ -18,22 +16,18 @@ use plinth::ui::widget::DropdownItem;
 fn main() {
     tracing_subscriber::fmt().pretty().init();
 
-    AppContextBuilder::default().run(DropdownDemo {});
-}
-
-struct DropdownDemo {}
-
-impl AppLifecycleHandler for DropdownDemo {
-    fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
-            WindowConfig {
-                title: "Dropdown Example".into(),
-                width: 600,
-                height: 500,
-            },
-            AppWindow::default().into_handler(),
-        );
-    }
+    AppContextBuilder::default()
+        .on_resume(|runtime| {
+            runtime.create_viewport(
+                WindowConfig {
+                    title: "Dropdown Example".into(),
+                    width: 600,
+                    height: 500,
+                },
+                AppWindow::default().into_handler(),
+            );
+        })
+        .run();
 }
 
 struct AppWindow {

--- a/examples/file_picker.rs
+++ b/examples/file_picker.rs
@@ -1,8 +1,6 @@
 #![allow(unused_crate_dependencies)]
 
-use plinth::shell::AppContext;
 use plinth::shell::AppContextBuilder;
-use plinth::shell::AppLifecycleHandler;
 use plinth::shell::Context;
 use plinth::shell::FileDialog;
 use plinth::shell::FolderDialog;
@@ -15,22 +13,18 @@ use plinth::ui::UiBuilder;
 
 fn main() {
     tracing_subscriber::fmt().pretty().init();
-    AppContextBuilder::default().run(Demo {});
-}
-
-struct Demo {}
-
-impl AppLifecycleHandler for Demo {
-    fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
-            WindowConfig {
-                title: "File Picker".into(),
-                width: 400,
-                height: 300,
-            },
-            AppWindow::default().into_handler(),
-        );
-    }
+    AppContextBuilder::default()
+        .on_resume(|runtime| {
+            runtime.create_viewport(
+                WindowConfig {
+                    title: "File Picker".into(),
+                    width: 400,
+                    height: 300,
+                },
+                AppWindow::default().into_handler(),
+            );
+        })
+        .run();
 }
 
 #[derive(Default)]

--- a/examples/layout_center.rs
+++ b/examples/layout_center.rs
@@ -1,7 +1,5 @@
 use plinth::graphics::Color;
-use plinth::shell::AppContext;
 use plinth::shell::AppContextBuilder;
-use plinth::shell::AppLifecycleHandler;
 use plinth::shell::Context;
 use plinth::shell::WindowConfig;
 use plinth::ui::Alignment;
@@ -27,22 +25,18 @@ fn main() {
         .with(def_filter)
         .init();
 
-    AppContextBuilder::default().run(App {});
-}
-
-struct App {}
-
-impl AppLifecycleHandler for App {
-    fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
-            WindowConfig {
-                title: "Sabre App".into(),
-                width: 800,
-                height: 600,
-            },
-            AppWindow::default().into_handler(),
-        );
-    }
+    AppContextBuilder::default()
+        .on_resume(|runtime| {
+            runtime.create_viewport(
+                WindowConfig {
+                    title: "Sabre App".into(),
+                    width: 800,
+                    height: 600,
+                },
+                AppWindow::default().into_handler(),
+            );
+        })
+        .run();
 }
 
 #[derive(Default)]

--- a/examples/temp_converter.rs
+++ b/examples/temp_converter.rs
@@ -7,9 +7,7 @@
 
 use plinth::graphics::Color;
 use plinth::graphics::Paint;
-use plinth::shell::AppContext;
 use plinth::shell::AppContextBuilder;
-use plinth::shell::AppLifecycleHandler;
 use plinth::shell::Context;
 use plinth::shell::WindowConfig;
 use plinth::ui::Alignment;
@@ -42,22 +40,19 @@ fn main() {
         )
         .unwrap();
 
-    AppContextBuilder::default().with_theme(theme).run(Demo {});
-}
-
-struct Demo {}
-
-impl AppLifecycleHandler for Demo {
-    fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
-            WindowConfig {
-                title: "Temperature Converter".into(),
-                width: 400,
-                height: 300,
-            },
-            AppWindow::default().into_handler(),
-        );
-    }
+    AppContextBuilder::default()
+        .with_theme(theme)
+        .on_resume(|runtime| {
+            runtime.create_viewport(
+                WindowConfig {
+                    title: "Temperature Converter".into(),
+                    width: 400,
+                    height: 300,
+                },
+                AppWindow::default().into_handler(),
+            );
+        })
+        .run();
 }
 
 #[derive(Default)]

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -1,8 +1,6 @@
 #![allow(unused_crate_dependencies)]
 
-use plinth::shell::AppContext;
 use plinth::shell::AppContextBuilder;
-use plinth::shell::AppLifecycleHandler;
 use plinth::shell::Context;
 use plinth::shell::WindowConfig;
 use plinth::ui::Alignment;
@@ -14,22 +12,18 @@ use plinth::ui::UiBuilder;
 fn main() {
     tracing_subscriber::fmt().pretty().init();
 
-    AppContextBuilder::default().run(TextEditDemo {});
-}
-
-struct TextEditDemo {}
-
-impl AppLifecycleHandler for TextEditDemo {
-    fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
-            WindowConfig {
-                title: "TextEdit Example".into(),
-                width: 800,
-                height: 600,
-            },
-            AppWindow::default().into_handler(),
-        );
-    }
+    AppContextBuilder::default()
+        .on_resume(|runtime| {
+            runtime.create_viewport(
+                WindowConfig {
+                    title: "TextEdit Example".into(),
+                    width: 800,
+                    height: 600,
+                },
+                AppWindow::default().into_handler(),
+            );
+        })
+        .run();
 }
 
 #[derive(Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 use plinth::graphics::Color;
 use plinth::graphics::Paint;
-use plinth::shell::AppContext;
 use plinth::shell::AppContextBuilder;
-use plinth::shell::AppLifecycleHandler;
 use plinth::shell::Context;
 use plinth::shell::WindowConfig;
 use plinth::ui::Alignment;
@@ -119,25 +117,19 @@ fn main() {
 
     AppContextBuilder::default()
         .with_theme(theme)
-        .run(SabreApp {});
-}
+        .on_resume(|runtime| {
+            info!("Starting up Sabre application...");
 
-#[derive(Default)]
-struct SabreApp {}
-
-impl AppLifecycleHandler for SabreApp {
-    fn resume(&mut self, runtime: &mut AppContext) {
-        info!("Starting up Sabre application...");
-
-        runtime.create_viewport(
-            WindowConfig {
-                title: "Sabre App".into(),
-                width: 800,
-                height: 600,
-            },
-            ViewportState::new().into_handler(),
-        );
-    }
+            runtime.create_viewport(
+                WindowConfig {
+                    title: "Sabre App".into(),
+                    width: 800,
+                    height: 600,
+                },
+                ViewportState::new().into_handler(),
+            );
+        })
+        .run();
 }
 
 struct ViewportState {}


### PR DESCRIPTION
## Summary
- Delete `pub trait AppLifecycleHandler`. It had one impl per binary, was never dispatched dynamically, and forced every consumer to write boilerplate.
- Add `AppContextBuilder::on_resume<F: FnMut(&mut AppContext) + 'static>(self, F) -> Self` and `on_suspend<F>(self, F) -> Self`. Both store `Box<dyn FnMut(&mut AppContext)>` on the builder.
- `AppContextBuilder::run` no longer takes an app argument.
- Wire suspend through `ApplicationHandler::destroy_surfaces`.
- Update `src/main.rs` and all six examples (`counter`, `dropdown`, `file_picker`, `layout_center`, `temp_converter`, `text_edit`) to the closure form.

Implements finding #15. Pre-1.0 API change.

## Test plan
- [x] `cargo check --examples --bin sabre --tests`
- [ ] Manual: `cargo run --bin sabre`, `cargo run --example counter`, `cargo run --example temp_converter` launch and accept input