### PR TITLE
Collapse Viewport into the winit window struct

### DIFF
--- a/crates/plinth/src/shell/app_context.rs
+++ b/crates/plinth/src/shell/app_context.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use slotmap::SlotMap;
 use smallvec::SmallVec;
 use winit::event_loop::ControlFlow;
 use winit::event_loop::EventLoop;
@@ -11,15 +10,12 @@ use crate::graphics::Color;
 use crate::graphics::GraphicsContext;
 use crate::graphics::TextLayoutContext;
 use crate::shell::Clipboard;
-use crate::shell::Input;
 use crate::shell::WindowConfig;
 use crate::ui::Theme;
 use crate::ui::UiBuilder;
 use crate::ui::text::TextLayoutStorage;
 
 use super::frame::Context;
-use super::window::Viewport;
-use super::window::ViewportId;
 use super::winit::DeferredCommand;
 use super::winit::WinitApp;
 use super::winit::WinitWindow;
@@ -43,7 +39,6 @@ impl AppContextBuilder {
 
         let runtime = WinitApp {
             runtime: AppContext {
-                viewports: SlotMap::with_key(),
                 clipboard: Clipboard::new(),
                 deferred_commands: Vec::new(),
                 theme,
@@ -69,7 +64,6 @@ pub trait AppLifecycleHandler: 'static {
 }
 
 pub struct AppContext {
-    pub(super) viewports: SlotMap<ViewportId, Viewport>,
     pub(super) clipboard: Clipboard,
     pub(super) deferred_commands: Vec<DeferredCommand>,
 
@@ -82,18 +76,13 @@ pub struct AppContext {
 }
 
 impl AppContext {
-    pub fn create_viewport(
+    pub fn create_window(
         &mut self,
         config: WindowConfig,
         handler: impl FnMut(Context, UiBuilder) + 'static,
     ) {
-        let id = self.viewports.insert(Viewport {
-            input: Input::default(),
-            config,
-        });
-
         self.deferred_commands.push(DeferredCommand::Create {
-            id,
+            config,
             handler: Box::new(handler),
         });
     }
@@ -113,12 +102,8 @@ impl AppContext {
         let mut outputs = SmallVec::with_capacity(windows.size_hint().0);
 
         for window in windows {
-            let Some(viewport) = self.viewports.get_mut(window.viewport) else {
-                continue;
-            };
-
             // borrow input for this frame
-            let mut input = std::mem::take(&mut viewport.input);
+            let mut input = std::mem::take(&mut window.input);
 
             let ui_builder = window.ui_context.begin_frame(
                 &mut self.clipboard,
@@ -133,19 +118,14 @@ impl AppContext {
             let context = Context {
                 window: window.window.as_ref(),
                 graphics,
-                viewports: &mut self.viewports,
                 deferred_commands: &mut self.deferred_commands,
             };
 
             (window.handler)(context, ui_builder);
 
-            // Restore input allocs for next frame; use branch to avoid unwrap.
-            // This should never fail.
-            if let Some(viewport) = self.viewports.get_mut(window.viewport) {
-                input.prev_pointer = input.pointer;
-                viewport.input = input;
-                viewport.input.keyboard_events.clear();
-            }
+            input.prev_pointer = input.pointer;
+            window.input = input;
+            window.input.keyboard_events.clear();
 
             window.canvas.reset(Color::BLACK);
             window.ui_context.finish(

--- a/crates/plinth/src/shell/frame.rs
+++ b/crates/plinth/src/shell/frame.rs
@@ -1,17 +1,12 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-use slotmap::SlotMap;
-
 use crate::graphics::GraphicsContext;
 use crate::graphics::Texture;
 use crate::graphics::TextureLoadError;
 use crate::ui::UiBuilder;
 
-use super::Input;
 use super::WindowConfig;
-use super::window::Viewport;
-use super::window::ViewportId;
 use super::winit::DeferredCommand;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -76,7 +71,6 @@ impl FolderDialog {
 pub struct Context<'a> {
     pub(super) window: &'a dyn winit::window::Window,
     pub(super) graphics: &'a mut GraphicsContext,
-    pub(super) viewports: &'a mut SlotMap<ViewportId, Viewport>,
     pub(super) deferred_commands: &'a mut Vec<DeferredCommand>,
 }
 
@@ -86,13 +80,8 @@ impl Context<'_> {
         config: WindowConfig,
         handler: impl FnMut(Context, UiBuilder) + 'static,
     ) {
-        let id = self.viewports.insert(Viewport {
-            input: Input::default(),
-            config,
-        });
-
         self.deferred_commands.push(DeferredCommand::Create {
-            id,
+            config,
             handler: Box::new(handler),
         });
     }

--- a/crates/plinth/src/shell/window.rs
+++ b/crates/plinth/src/shell/window.rs
@@ -1,21 +1,8 @@
 use std::borrow::Cow;
 
-use slotmap::new_key_type;
-
-use super::Input;
-
 #[derive(Clone, Debug)]
 pub struct WindowConfig {
     pub title: Cow<'static, str>,
     pub width: u32,
     pub height: u32,
-}
-
-new_key_type! {
-    pub(super) struct ViewportId;
-}
-
-pub(super) struct Viewport {
-    pub(super) input: Input,
-    pub(super) config: WindowConfig,
 }

--- a/crates/plinth/src/shell/winit.rs
+++ b/crates/plinth/src/shell/winit.rs
@@ -12,7 +12,9 @@ use winit::window::WindowId;
 
 use crate::graphics::Canvas;
 use crate::graphics::GraphicsContext;
+use crate::shell::Input;
 use crate::shell::KeyboardEvent;
+use crate::shell::WindowConfig;
 use crate::ui::UiBuilder;
 use crate::ui::context::UiContext;
 
@@ -20,21 +22,21 @@ use super::app_context::AppContext;
 use super::app_context::AppLifecycleHandler;
 use super::frame::Context;
 use super::input::DoubleClickTracker;
-use super::window::ViewportId;
 
 pub(super) struct WinitWindow {
     pub window: Arc<dyn Window>,
     pub double_click_tracker: DoubleClickTracker,
 
     pub canvas: Canvas,
-    pub viewport: ViewportId,
     pub ui_context: UiContext,
+    pub input: Input,
+    pub config: WindowConfig,
     pub handler: Box<dyn FnMut(Context, UiBuilder)>,
 }
 
 pub(super) enum DeferredCommand {
     Create {
-        id: ViewportId,
+        config: WindowConfig,
         handler: Box<dyn FnMut(Context, UiBuilder)>,
     },
 }
@@ -50,7 +52,7 @@ impl<App> WinitApp<App> {
     fn handle_deferred_commands(&mut self, event_loop: &dyn ActiveEventLoop) {
         for command in self.runtime.deferred_commands.drain(..) {
             match command {
-                DeferredCommand::Create { id, handler } => {
+                DeferredCommand::Create { config, handler } => {
                     let window = Arc::<dyn Window>::from(
                         event_loop
                             .create_window(
@@ -75,7 +77,8 @@ impl<App> WinitApp<App> {
                             canvas: graphics.create_canvas(),
                             handler,
                             ui_context: UiContext::default(),
-                            viewport: id,
+                            input: Input::default(),
+                            config,
                             double_click_tracker: DoubleClickTracker::load_parameters(
                                 window.scale_factor(),
                             ),
@@ -86,7 +89,7 @@ impl<App> WinitApp<App> {
             }
         }
 
-        if self.runtime.viewports.is_empty() {
+        if self.windows.is_empty() {
             event_loop.exit();
         }
     }
@@ -111,9 +114,8 @@ impl<App: AppLifecycleHandler> ApplicationHandler for WinitApp<App> {
         match event {
             WindowEvent::PointerMoved { position, .. } => {
                 let window = self.windows.get_mut(&window_id).unwrap();
-                let viewport = self.runtime.viewports.get_mut(window.viewport).unwrap();
 
-                viewport.input.pointer = glamour::Point2 {
+                window.input.pointer = glamour::Point2 {
                     x: position.x as f32,
                     y: position.y as f32,
                 };
@@ -122,7 +124,6 @@ impl<App: AppLifecycleHandler> ApplicationHandler for WinitApp<App> {
             }
             WindowEvent::PointerButton { state, button, .. } => {
                 let window = self.windows.get_mut(&window_id).unwrap();
-                let viewport = self.runtime.viewports.get_mut(window.viewport).unwrap();
 
                 let ButtonSource::Mouse(button) = button else {
                     return;
@@ -131,26 +132,26 @@ impl<App: AppLifecycleHandler> ApplicationHandler for WinitApp<App> {
                 let click_count =
                     window
                         .double_click_tracker
-                        .on_click(button, state, viewport.input.pointer);
+                        .on_click(button, state, window.input.pointer);
 
                 match (button, state) {
                     (winit::event::MouseButton::Left, winit::event::ElementState::Pressed) => {
-                        viewport.input.mouse_state.left_click_count = click_count;
+                        window.input.mouse_state.left_click_count = click_count;
                     }
                     (winit::event::MouseButton::Left, winit::event::ElementState::Released) => {
-                        viewport.input.mouse_state.left_click_count = click_count;
+                        window.input.mouse_state.left_click_count = click_count;
                     }
                     (winit::event::MouseButton::Right, winit::event::ElementState::Pressed) => {
-                        viewport.input.mouse_state.right_click_count = click_count;
+                        window.input.mouse_state.right_click_count = click_count;
                     }
                     (winit::event::MouseButton::Right, winit::event::ElementState::Released) => {
-                        viewport.input.mouse_state.right_click_count = click_count;
+                        window.input.mouse_state.right_click_count = click_count;
                     }
                     (winit::event::MouseButton::Middle, winit::event::ElementState::Pressed) => {
-                        viewport.input.mouse_state.middle_click_count = click_count;
+                        window.input.mouse_state.middle_click_count = click_count;
                     }
                     (winit::event::MouseButton::Middle, winit::event::ElementState::Released) => {
-                        viewport.input.mouse_state.middle_click_count = click_count;
+                        window.input.mouse_state.middle_click_count = click_count;
                     }
                     _ => {
                         return;
@@ -160,10 +161,9 @@ impl<App: AppLifecycleHandler> ApplicationHandler for WinitApp<App> {
                 window.window.request_redraw();
             }
             WindowEvent::KeyboardInput { event, .. } => {
-                let window = self.windows.get(&window_id).unwrap();
-                let viewport = self.runtime.viewports.get_mut(window.viewport).unwrap();
+                let window = self.windows.get_mut(&window_id).unwrap();
 
-                viewport.input.keyboard_events.push(KeyboardEvent {
+                window.input.keyboard_events.push(KeyboardEvent {
                     key: event.physical_key,
                     text: event.text,
                     location: event.location,
@@ -174,25 +174,21 @@ impl<App: AppLifecycleHandler> ApplicationHandler for WinitApp<App> {
                 window.window.request_redraw();
             }
             WindowEvent::ModifiersChanged(modifiers) => {
-                let window = self.windows.get(&window_id).unwrap();
-                let viewport = self.runtime.viewports.get_mut(window.viewport).unwrap();
+                let window = self.windows.get_mut(&window_id).unwrap();
 
-                viewport.input.modifiers = modifiers.state();
+                window.input.modifiers = modifiers.state();
             }
             WindowEvent::SurfaceResized(physical_size) => {
-                let window = self.windows.get(&window_id).unwrap();
-                let viewport = self.runtime.viewports.get_mut(window.viewport).unwrap();
+                let window = self.windows.get_mut(&window_id).unwrap();
 
-                viewport.config.width = physical_size.width;
-                viewport.config.height = physical_size.height;
+                window.config.width = physical_size.width;
+                window.config.height = physical_size.height;
 
-                viewport.input.window_size.width = physical_size.width as f32;
-                viewport.input.window_size.height = physical_size.height as f32;
+                window.input.window_size.width = physical_size.width as f32;
+                window.input.window_size.height = physical_size.height as f32;
             }
             WindowEvent::CloseRequested => {
-                let window = self.windows.remove(&window_id).unwrap();
-
-                self.runtime.viewports.remove(window.viewport);
+                self.windows.remove(&window_id);
 
                 let graphics = self.runtime.graphics.as_mut().unwrap();
                 graphics.destroy_surface(window_id);
@@ -205,9 +201,7 @@ impl<App: AppLifecycleHandler> ApplicationHandler for WinitApp<App> {
             WindowEvent::Focused(is_focused) if is_focused => {
                 let window = self.windows.get_mut(&window_id).unwrap();
                 window.double_click_tracker.on_activate();
-
-                let viewport = self.runtime.viewports.get_mut(window.viewport).unwrap();
-                viewport.input.focus_changed();
+                window.input.focus_changed();
                 window.window.request_redraw();
             }
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -24,7 +24,7 @@ struct Demo {}
 
 impl AppLifecycleHandler for Demo {
     fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
+        runtime.create_window(
             WindowConfig {
                 title: "Counter".into(),
                 width: 400,

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -25,7 +25,7 @@ struct DropdownDemo {}
 
 impl AppLifecycleHandler for DropdownDemo {
     fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
+        runtime.create_window(
             WindowConfig {
                 title: "Dropdown Example".into(),
                 width: 600,

--- a/examples/file_picker.rs
+++ b/examples/file_picker.rs
@@ -22,7 +22,7 @@ struct Demo {}
 
 impl AppLifecycleHandler for Demo {
     fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
+        runtime.create_window(
             WindowConfig {
                 title: "File Picker".into(),
                 width: 400,

--- a/examples/layout_center.rs
+++ b/examples/layout_center.rs
@@ -34,7 +34,7 @@ struct App {}
 
 impl AppLifecycleHandler for App {
     fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
+        runtime.create_window(
             WindowConfig {
                 title: "Sabre App".into(),
                 width: 800,

--- a/examples/temp_converter.rs
+++ b/examples/temp_converter.rs
@@ -49,7 +49,7 @@ struct Demo {}
 
 impl AppLifecycleHandler for Demo {
     fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
+        runtime.create_window(
             WindowConfig {
                 title: "Temperature Converter".into(),
                 width: 400,

--- a/examples/text_edit.rs
+++ b/examples/text_edit.rs
@@ -21,7 +21,7 @@ struct TextEditDemo {}
 
 impl AppLifecycleHandler for TextEditDemo {
     fn resume(&mut self, runtime: &mut AppContext) {
-        runtime.create_viewport(
+        runtime.create_window(
             WindowConfig {
                 title: "TextEdit Example".into(),
                 width: 800,

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ impl AppLifecycleHandler for SabreApp {
     fn resume(&mut self, runtime: &mut AppContext) {
         info!("Starting up Sabre application...");
 
-        runtime.create_viewport(
+        runtime.create_window(
             WindowConfig {
                 title: "Sabre App".into(),
                 width: 800,


### PR DESCRIPTION
## Summary
- Fold `Viewport.input` and `Viewport.config` into `WinitWindow`. Every winit event handler is now one lookup (`self.windows.get_mut(&window_id)`) instead of two.
- Drop `Viewport`, `ViewportId`, the `slotmap::new_key_type!` macro in `window.rs`, and `AppContext.viewports: SlotMap<...>`.
- `DeferredCommand::Create` now carries `config` directly (no pre-allocated id) — the `WindowId` is assigned when winit creates the window.
- Public API: rename `AppContext::create_viewport` to `AppContext::create_window` (consistent with the existing `Context::create_window`). Updates `src/main.rs` and all six examples.
- Exit condition switches to `if self.windows.is_empty()` (the previous check on `viewports.is_empty()` is now equivalent).

Implements finding #16. Pre-1.0 API change.

## Test plan
- [x] `cargo check --examples --bin sabre --tests`
- [x] `cargo check --all-targets` no warnings introduced
- [x] Manual: `cargo run --bin sabre`, `cargo run --example counter`, `cargo run --example file_picker` for multi-window/dialog flows; resize, click, keyboard input, and clean close all work.