### PR TITLE
[codex] resolve styles into snapshots

### DIFF
--- a/crates/plinth/src/ui/builder.rs
+++ b/crates/plinth/src/ui/builder.rs
@@ -6,7 +6,6 @@ use rapidhash::v3::rapidhash_v3;
 use crate::graphics::Color;
 use crate::graphics::GradientPaint;
 use crate::graphics::Paint;
-use crate::graphics::TextAlignment;
 use crate::graphics::TextLayoutContext;
 use crate::shell::Clipboard;
 use crate::shell::Input;
@@ -70,18 +69,18 @@ impl UiBuilder<'_> {
     }
 
     pub fn apply_style(&mut self, class: StyleClass, state: StateFlags) -> &mut Self {
-        let style = self.theme.get(class);
-
-        // Paint
-        let paint = style.background.get(state);
-        let border = style.border.get(state);
-        let border_width = style.border_widths.get(state);
-        let corner_radii = style.corner_radii.get(state);
-        self.paint(paint, border, border_width, corner_radii);
-
-        // Layout
         self.style_id = self.theme.get_id(class);
         self.state = state;
+
+        let style = self.theme.resolve_widget_style(self.style_id, state);
+        let paint = style.paint;
+        let layout = style.layout;
+        self.paint(
+            paint.background,
+            paint.border,
+            paint.border_widths,
+            paint.corner_radii,
+        );
 
         let atom = self.context.ui_tree.atom_mut(self.index);
         // Preserve overlay fields set by the overlay builder API before applying the style.
@@ -89,14 +88,14 @@ impl UiBuilder<'_> {
         let z_layer = atom.z_layer;
         let is_modal = atom.is_modal;
         *atom = Atom {
-            width: style.width.get(state),
-            height: style.height.get(state),
-            inner_padding: style.padding.get(state),
-            major_align: style.child_major_alignment.get(state),
-            minor_align: style.child_minor_alignment.get(state),
-            direction: style.child_direction.get(state),
-            inter_child_padding: style.child_spacing.get(state),
-            clip_overflow: style.clip_children.get(state),
+            width: layout.width,
+            height: layout.height,
+            inner_padding: layout.padding,
+            major_align: layout.child_major_alignment,
+            minor_align: layout.child_minor_alignment,
+            direction: layout.child_direction,
+            inter_child_padding: layout.child_spacing,
+            clip_overflow: layout.clip_children,
             position,
             z_layer,
             is_modal,
@@ -300,7 +299,8 @@ impl UiBuilder<'_> {
 
         let alignment = self
             .theme
-            .resolve_style::<TextAlignment>(self.style_id, self.state);
+            .resolve_text_style(self.style_id, self.state)
+            .text_align;
         let size = text_layout.layout.calculate_content_widths();
 
         self.context.ui_tree.add(

--- a/crates/plinth/src/ui/style/properties.rs
+++ b/crates/plinth/src/ui/style/properties.rs
@@ -109,6 +109,92 @@ macros::declare_style! {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ResolvedWidgetStyle {
+    pub(crate) paint: ResolvedPaintStyle,
+    pub(crate) layout: ResolvedLayoutStyle,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ResolvedPaintStyle {
+    pub(crate) background: Paint,
+    pub(crate) border: GradientPaint,
+    pub(crate) border_widths: BorderWidths,
+    pub(crate) corner_radii: CornerRadii,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct ResolvedLayoutStyle {
+    pub(crate) width: Size,
+    pub(crate) height: Size,
+    pub(crate) padding: Padding,
+    pub(crate) child_major_alignment: Alignment,
+    pub(crate) child_minor_alignment: Alignment,
+    pub(crate) child_spacing: f32,
+    pub(crate) child_direction: LayoutDirection,
+    pub(crate) clip_children: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ResolvedTextStyle {
+    pub(crate) font: Arc<crate::graphics::Font>,
+    pub(crate) font_size: u16,
+    pub(crate) font_style: FontStyle,
+    pub(crate) font_weight: u16,
+    pub(crate) strikethrough_color: Color,
+    pub(crate) strikethrough_offset: f32,
+    pub(crate) text_align: TextAlignment,
+    pub(crate) text_color: Color,
+    pub(crate) underline_color: Color,
+    pub(crate) underline_offset: f32,
+}
+
+impl Style {
+    pub(crate) fn resolve_widget_style(&self, state: StateFlags) -> ResolvedWidgetStyle {
+        ResolvedWidgetStyle {
+            paint: self.resolve_paint_style(state),
+            layout: self.resolve_layout_style(state),
+        }
+    }
+
+    pub(crate) fn resolve_paint_style(&self, state: StateFlags) -> ResolvedPaintStyle {
+        ResolvedPaintStyle {
+            background: self.background.get(state),
+            border: self.border.get(state),
+            border_widths: self.border_widths.get(state),
+            corner_radii: self.corner_radii.get(state),
+        }
+    }
+
+    pub(crate) fn resolve_layout_style(&self, state: StateFlags) -> ResolvedLayoutStyle {
+        ResolvedLayoutStyle {
+            width: self.width.get(state),
+            height: self.height.get(state),
+            padding: self.padding.get(state),
+            child_major_alignment: self.child_major_alignment.get(state),
+            child_minor_alignment: self.child_minor_alignment.get(state),
+            child_spacing: self.child_spacing.get(state),
+            child_direction: self.child_direction.get(state),
+            clip_children: self.clip_children.get(state),
+        }
+    }
+
+    pub(crate) fn resolve_text_style(&self, state: StateFlags) -> ResolvedTextStyle {
+        ResolvedTextStyle {
+            font: self.font.get(state),
+            font_size: self.font_size.get(state),
+            font_style: self.font_style.get(state),
+            font_weight: self.font_weight.get(state),
+            strikethrough_color: self.strikethrough_color.get(state),
+            strikethrough_offset: self.strikethrough_offset.get(state),
+            text_align: self.text_align.get(state),
+            text_color: self.text_color.get(state),
+            underline_color: self.underline_color.get(state),
+            underline_offset: self.underline_offset.get(state),
+        }
+    }
+}
+
 mod macros {
     /// Generates:
     /// - `Style` struct with StatefulProperty<T> for each property

--- a/crates/plinth/src/ui/theme.rs
+++ b/crates/plinth/src/ui/theme.rs
@@ -13,6 +13,8 @@ use super::Size;
 use super::style::BorderWidths;
 use super::style::CornerRadii;
 use super::style::PropertyKey;
+use super::style::ResolvedTextStyle;
+use super::style::ResolvedWidgetStyle;
 use super::style::StateFlags;
 use super::style::Style;
 use super::style::StyleError;
@@ -126,6 +128,25 @@ impl Theme {
         self.styles.resolve::<K>(style_id, state)
     }
 
+    pub(crate) fn resolve_widget_style(
+        &self,
+        style_id: StyleId,
+        state: StateFlags,
+    ) -> ResolvedWidgetStyle {
+        self.styles
+            .get(style_id)
+            .unwrap()
+            .resolve_widget_style(state)
+    }
+
+    pub(crate) fn resolve_text_style(
+        &self,
+        style_id: StyleId,
+        state: StateFlags,
+    ) -> ResolvedTextStyle {
+        self.styles.get(style_id).unwrap().resolve_text_style(state)
+    }
+
     /// Creates a new style with the given parent and properties.
     ///
     /// The style can then be assigned to one or more `StyleClass`es using
@@ -158,61 +179,46 @@ impl Theme {
         state: StateFlags,
         builder: &mut parley::RangedBuilder<Color>,
     ) {
-        use parley::StyleProperty as Prop;
-
-        let style = self.enumerate_styles(style_id, state, |prop| {
-            builder.push_default(prop);
-        });
-
-        match &style.font.get(state).family {
-            FontStack::Source(cow) => {
-                builder.push_default(Prop::FontFamily(parley::FontFamily::Source(cow.clone())));
-            }
-            FontStack::Single(font_family) => {
-                builder.push_default(Prop::FontFamily(parley::FontFamily::Single(
-                    font_family.clone().into(),
-                )));
-            }
-            FontStack::List(cow) => {
-                let families = cow
-                    .iter()
-                    .cloned()
-                    .map(|f| f.into())
-                    .collect::<SmallVec<[parley::FontFamilyName; 4]>>();
-                builder.push_default(Prop::FontFamily(families.as_slice().into()));
-            }
-        }
+        let text = self.resolve_text_style(style_id, state);
+        push_resolved_text_defaults(&text, builder);
     }
+}
 
-    fn enumerate_styles<'a>(
-        &self,
-        style_id: StyleId,
-        state: StateFlags,
-        mut callback: impl FnMut(parley::StyleProperty<'a, Color>),
-    ) -> &Style {
-        use parley::StyleProperty as Prop;
+fn push_resolved_text_defaults(
+    text: &ResolvedTextStyle,
+    builder: &mut parley::RangedBuilder<Color>,
+) {
+    use parley::StyleProperty as Prop;
 
-        let style = self.styles.get(style_id).unwrap();
+    builder.push_default(Prop::FontFeatures(default_font_features()));
+    builder.push_default(Prop::Brush(text.text_color));
+    builder.push_default(Prop::FontSize(text.font_size as f32));
+    builder.push_default(Prop::FontStyle(text.font_style.into()));
+    builder.push_default(Prop::FontWeight(parley::FontWeight::new(
+        text.font_weight as f32,
+    )));
+    builder.push_default(Prop::StrikethroughBrush(Some(text.strikethrough_color)));
+    builder.push_default(Prop::StrikethroughOffset(Some(text.strikethrough_offset)));
+    builder.push_default(Prop::UnderlineBrush(Some(text.underline_color)));
+    builder.push_default(Prop::UnderlineOffset(Some(text.underline_offset)));
 
-        callback(Prop::FontFeatures(default_font_features()));
-        callback(Prop::Brush(style.text_color.get(state)));
-        callback(Prop::FontSize(style.font_size.get(state) as f32));
-        callback(Prop::FontStyle(style.font_style.get(state).into()));
-        callback(Prop::FontWeight(parley::FontWeight::new(
-            style.font_weight.get(state) as f32,
-        )));
-        callback(Prop::StrikethroughBrush(Some(
-            style.strikethrough_color.get(state),
-        )));
-        callback(Prop::StrikethroughOffset(Some(
-            style.strikethrough_offset.get(state),
-        )));
-        callback(Prop::UnderlineBrush(Some(style.underline_color.get(state))));
-        callback(Prop::UnderlineOffset(Some(
-            style.underline_offset.get(state),
-        )));
-
-        style
+    match &text.font.family {
+        FontStack::Source(cow) => {
+            builder.push_default(Prop::FontFamily(parley::FontFamily::Source(cow.clone())));
+        }
+        FontStack::Single(font_family) => {
+            builder.push_default(Prop::FontFamily(parley::FontFamily::Single(
+                font_family.clone().into(),
+            )));
+        }
+        FontStack::List(cow) => {
+            let families = cow
+                .iter()
+                .cloned()
+                .map(|f| f.into())
+                .collect::<SmallVec<[parley::FontFamilyName; 4]>>();
+            builder.push_default(Prop::FontFamily(families.as_slice().into()));
+        }
     }
 }
 

--- a/crates/plinth/src/ui/widget/dropdown.rs
+++ b/crates/plinth/src/ui/widget/dropdown.rs
@@ -73,12 +73,13 @@ impl<'a> Dropdown<'a> {
 
         if is_open {
             let button_style = button.theme().get(StyleClass::Button);
-            let radii = button_style.corner_radii.get(state);
+            let button_paint = button_style.resolve_paint_style(state);
+            let radii = button_paint.corner_radii;
 
             button.paint(
-                button_style.background.get(state),
-                button_style.border.get(state),
-                button_style.border_widths.get(state),
+                button_paint.background,
+                button_paint.border,
+                button_paint.border_widths,
                 CornerRadii {
                     top_left: radii.top_left,
                     top_right: radii.top_right,
@@ -331,8 +332,8 @@ impl<'a> Dropdown<'a> {
         let button_padding = item
             .theme()
             .get(StyleClass::Button)
-            .padding
-            .get(effective_state);
+            .resolve_layout_style(effective_state)
+            .padding;
 
         item.apply_style(StyleClass::DropdownItem, effective_state);
         item.set_clip_children(true);

--- a/crates/plinth/src/ui/widget/frame.rs
+++ b/crates/plinth/src/ui/widget/frame.rs
@@ -24,16 +24,12 @@ pub struct Frame<'a> {
 impl<'a> Frame<'a> {
     pub fn new(builder: &'a mut UiBuilder<'_>) -> Self {
         let style = builder.theme().get(StyleClass::Surface);
-
-        let major_alignment = style.child_major_alignment.get(StateFlags::NORMAL);
-        let minor_alignment = style.child_minor_alignment.get(StateFlags::NORMAL);
-        let spacing = style.child_spacing.get(StateFlags::NORMAL);
-        let direction = style.child_direction.get(StateFlags::NORMAL);
+        let layout = style.resolve_layout_style(StateFlags::NORMAL);
 
         let mut child = builder.child();
-        child.child_alignment(major_alignment, minor_alignment);
-        child.child_spacing(spacing);
-        child.child_direction(direction);
+        child.child_alignment(layout.child_major_alignment, layout.child_minor_alignment);
+        child.child_spacing(layout.child_spacing);
+        child.child_direction(layout.child_direction);
 
         Self { builder: child }
     }


### PR DESCRIPTION
## Summary

- Add short-lived resolved style snapshots for widget, paint, layout, and text style data.
- Route `UiBuilder::apply_style` through a widget style snapshot instead of scattered per-property reads.
- Reuse the text snapshot for Parley defaults and update manual dropdown/frame style lookups to use the same pattern.

## Why

This makes the style hot path more data-oriented without adding a retained style-state cache. The registry still stores the same inherited `StatefulProperty` data; the resolved structs are temporary values created when widgets apply styles.

## Validation

- `cargo fmt --check`
- `cargo check -p plinth`